### PR TITLE
Remove bare references to variables causing deprecation warnings.

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -46,7 +46,7 @@
 
             Ed25519 MASTER KEY detected on the relay - it is NOT supposed to be there! Aborting."
   when: item.stat.exists == True
-  with_items: masterkeycheck.results
+  with_items: "{{ masterkeycheck.results }}"
 
 - name: Collect fingerprints for MyFamily (LOCAL)
   shell: cut {{ tor_offline_masterkey_dir }}/*/fingerprint -d" " -f2|xargs|sed -e 's/ /,/g'
@@ -66,8 +66,8 @@
   become: yes
   file: path={{ tor_ConfDir }}/{{ item.0.ipv4 }}_{{ item.1.orport }} state=directory mode=755
   with_nested:
-   - tor_ips
-   - tor_ports
+   - "{{ tor_ips }}"
+   - "{{ tor_ports }}"
   when: ansible_pkg_mgr == 'apt'
 
 - name: Ensure DataDir exists
@@ -133,7 +133,7 @@
 
    mv secret_id_key.untrustedremotekey secret_id_key"'
   when: item.stdout != "1"
-  with_items: rsakey.results
+  with_items: "{{ rsakey.results }}"
 
 # this task is separated from the task named "Ensure RSA key is in place" because it is not run with 'force=no'
 - name: Transmit new Ed25519 signing keys
@@ -187,8 +187,8 @@
     backup=yes
     validate="tor --verify-config -f %s"
   with_nested:
-   - tor_ips
-   - tor_ports
+   - "{{ tor_ips }}"
+   - "{{ tor_ports }}"
   register: instances
   tags:
    - reconfigure

--- a/tasks/linux_service.yml
+++ b/tasks/linux_service.yml
@@ -28,7 +28,7 @@
 - name: Ensure Tor instances are reloaded if its torrc changed (Linux/systemd)
   become: yes
   service: name=tor@{{ item.item.0.ipv4 }}_{{ item.item.1.orport }}.service state=reloaded
-  with_items: instances.results
+  with_items: "{{ instances.results }}"
   when: item.changed == True
   tags:
    - reconfigure
@@ -37,5 +37,5 @@
   become: yes
   service: name=tor@{{ item.0.ipv4 }}_{{ item.1.orport }}.service enabled=yes state=started
   with_nested:
-   - tor_ips
-   - tor_ports
+   - "{{ tor_ips }}"
+   - "{{ tor_ports }}"


### PR DESCRIPTION
I've been using this role with ansible 2.0.2.0 and I noticed a number of deprecation warnings due to the use of "bare" variables.  The warning looks something like this:

[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{tor_ports}}').

I believe there are more instances, but these are the ones I see when running against a Debian Jessie host.  I didn't attempt to fix the others because I didn't want to accidentally break other targets that I can't easily test.