### PR TITLE
Add support for ControlPort and CookieAuthentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,15 @@ All variables mentioned here are optional.
     - authentication relies on filesystem permissions
     - default: False
 
+* `tor_enableControlPort`
+    - enables an automatically determined ControlPort for each instance
+    - authentication via CookieAuthentication unless `tor_CookieAuthentication` is set to 0
+    - default: False
+
+* `tor_enableCookieAuthentication`
+    - enable CookieAuthentication for ControlPort
+    - default: False (unless `tor_enableControlPort` is true)
+
 * `freebsd_somaxconn`
     - configure kern.ipc.somaxconn on FreeBSD
     - by default we increase this value to at least 1024

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,6 +59,7 @@ tor_RunAsDaemon: 1
 tor_SocksPort: 0
 
 tor_enableControlSocket: False
+tor_enableControlPort: False
 
 tor_shutdownwaitlength: 1
 

--- a/templates/torrc
+++ b/templates/torrc
@@ -24,6 +24,16 @@ OfflineMasterKey 1
 ControlSocket {{ tor_DataDir }}/{{ item.0.ipv4 }}_{{ item.1.orport }}/controlsocket
 {% else %}
 ControlSocket 0
+{% endif %}
+{% if tor_enableControlPort == True %}
+ControlPort auto
+{% else %}
+ControlPort 0
+{% endif %}
+{# enable CookieAuthentication by default if ControlPort is enabled #}
+{% if tor_enableCookieAuthentication|default(False, true) == True or (tor_enableControlPort == True and tor_enableCookieAuthentication|default(True) == True) %}
+CookieAuthentication 1
+{% else %}
 CookieAuthentication 0
 {% endif %}
 


### PR DESCRIPTION
I thought it would be nice to enable CookieAuthentication if ControlPort is enabled and the user hasn't explicitly disabled CookieAuthentication, but it does make the template a bit complicated.  I'd be glad to change that if you like.