### PR TITLE
Remove whitespace created by wc on macOS

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -27,7 +27,7 @@
    - renewkey
 
 - name: Detect duplicate relay keys across relays (LOCAL)
-  shell: sha1sum {{ tor_offline_masterkey_dir }}/*/keys/secret_id_key {{ tor_offline_masterkey_dir }}/*/keys/ed25519_master_id_secret_key|cut -d/ -f1|sort|uniq -d|wc -l
+  shell: sha1sum {{ tor_offline_masterkey_dir }}/*/keys/secret_id_key {{ tor_offline_masterkey_dir }}/*/keys/ed25519_master_id_secret_key|cut -d/ -f1|sort|uniq -d|wc -l|sed -e 's/ //g'
   delegate_to: 127.0.0.1
   register: dupcount
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -127,7 +127,7 @@
    - [ 'secret_id_key' ]
 
 - name: Compare local vs. remote RSA key (secret_id_key)
-  local_action: shell sha1sum {{ tor_offline_masterkey_dir }}/{{ inventory_hostname }}-"{{ item.0.ipv4 }}_{{ item.1.orport }}"/keys/secret_id_key*|cut -d/ -f1|uniq -d|wc -l
+  local_action: shell sha1sum {{ tor_offline_masterkey_dir }}/{{ inventory_hostname }}-"{{ item.0.ipv4 }}_{{ item.1.orport }}"/keys/secret_id_key*|cut -d/ -f1|uniq -d|wc -l|sed -e 's/ //g'
   with_nested:
    - "{{ tor_ips }}"
    - "{{ tor_ports }}"


### PR DESCRIPTION
Hi, thanks for this role!

This PR fixes an issue with `wc -l` on macOS (and before), wherein the command outputs with leading whitespace, causing the variable checks in the next steps to fail.