### PR TITLE
check local requirements

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,13 @@
   tags:
     - always
 
+- name: Check for local requirements
+  shell: command -V tor && command -V sha1sum && command -V sort && command -V uniq && command -V wc && command -V cut && command -V xargs && command -V sed
+  run_once: true
+  delegate_to: 127.0.0.1
+  tags:
+    - always
+
 - name: Set OS specific variables
   include_vars: "{{ ansible_os_family }}.yml"
   tags:


### PR DESCRIPTION
This works on macOS and should work on everything else. The output is descriptive if the check fails, e.g. `sha1sum not found`. I also added ` xargs` and `sed` to the checks, so perhaps the readme should mention them too?