### PR TITLE
Bump required Ansible version to 2.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Control Machine Requirements
 - tor >= 0.2.7
 - python-netaddr package must be installed
 - required commands: openssl, sort, uniq, wc, cut, sed, xargs
-- ansible >= 2.1.3
+- ansible >= 2.1.4
 
 Managed Node Requirements
 
@@ -107,7 +107,7 @@ All variables mentioned here are optional.
     - all instances MUST be present in the csv file
     - default: none
 
-* `tor_ExitRelay` boolean 
+* `tor_ExitRelay` boolean
     - You will want to set this to True if you want to run exit relays.
     - default: False
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,5 +29,5 @@ galaxy_info:
     - ipv6
     - anonymity
     - networking
-  min_ansible_version: 2.1.3
+  min_ansible_version: 2.1.4
 dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,8 +3,8 @@
 - name: Check for vulnerable ansible version (CVE-2016-8614, CVE-2016-8628)
   assert:
     that:
-      - "{{ ansible_version.full | version_compare('2.1.3.0', '>=') }}"
-    msg: "VULNERABLE ansible version DETECTED, please update to v2.1.3 or newer! Exiting."
+      - "{{ ansible_version.full | version_compare('2.1.4.0', '>=') }}"
+    msg: "VULNERABLE ansible version DETECTED, please update to v2.1.4 or newer! Exiting."
   run_once: true
   delegate_to: 127.0.0.1
   tags:


### PR DESCRIPTION
Ref: https://www.ansible.com/security
Ref: https://blog.fefe.de/?ts=a6895f34
Ref: https://www.computest.nl/advisories/CT-2017-0109_Ansible.txt

Related to: #82

Note that while Ansible fixed those CVEs, some advanced templating broke because of it. You might want to check that the role works with 2.1.4, or if it requires those currently unreleased fixes which are on [stable-2.1](https://github.com/ansible/ansible/tree/stable-2.1).

Mechanical edit done by: [ansible-update-min-version](https://github.com/ypid/ypid-ansible-common/blob/master/bin/ansible-update-min-version)

```Shell
ansible-update-min-version meta/main.yml --update-text-file tasks/main.yml README.md
```