### PR TITLE
Add `play::security-assertions` Ansible tag

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,7 @@
   delegate_to: 127.0.0.1
   tags:
     - always
+    - 'play::security-assertions'
 
 - name: Check for local requirements
   shell: command -V tor && command -V openssl && command -V sort && command -V uniq && command -V wc && command -V cut && command -V xargs && command -V sed


### PR DESCRIPTION
This tag name is used in DebOps for the same thing. Supporting this in the role would improve user experience for DebOps users for the wrapper role (WIP).

Ref:

* https://github.com/ypid/ansible-tor
* https://github.com/debops/debops-playbooks/issues/339