### PR TITLE
Only enable Sandbox by default if kernel is new enough.

### DIFF
--- a/templates/torrc
+++ b/templates/torrc
@@ -47,7 +47,7 @@ Nickname {{ tor_nickname |regex_replace('[^a-zA-Z0-9]', '') |truncate(19, True, 
 
 {% if tor_Sandbox is defined %}
 Sandbox {{ tor_Sandbox }}
-{% elif ansible_os_family == 'Debian' %}
+{% elif ansible_os_family == 'Debian' and ansible_kernel|version_compare('3.5', '>=') %}
 Sandbox 1
 {% endif %}
 {% if tor_ExitRelay == True %}


### PR DESCRIPTION
I'm not sure how reliable this version comparison actually is, but it does work as expected on all of my Debian relays.

I chose version 3.5 due to the comment on the ticket below by yawning, which seems to agree with various other sources I could find.

https://trac.torproject.org/projects/tor/ticket/23090