### PR TITLE
add openssl version requirement to README.md to address #118

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Control Machine Requirements
 - do **not** run this role with `become: yes`
 - tor >= 0.2.8
 - python-netaddr package must be installed
-- required commands: openssl, sort, uniq, wc, cut, sed, xargs
+- required commands: sort, uniq, wc, cut, sed, xargs
+- openssl >= 1.0.0
 - ansible >= 2.3.1
 
 Managed Node Requirements


### PR DESCRIPTION
openssl version 1.0.0 introduced "openssl sha256" (and the -r option) as per the changelog https://www.openssl.org/news/changelog.html#x38 / source https://github.com/openssl/openssl/blob/OpenSSL_1_0_0-stable/apps/dgst.c