### PR TITLE
Feat/test kitchen ci

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,42 @@
+---
+driver:
+  name: vagrant
+  customize:
+    memory: 512
+
+platforms:
+  - name: debian-8
+  - name: debian-9
+  - name: ubuntu-16.04
+  - name: centos-7
+  - name: fedora-27
+    driver:
+      provision: True
+      vagrantfiles:
+        - test/vagrant_provisions/fedora27_vagrant_provision.rb
+  - name: freebsd-10
+    driver:
+      provision: True
+      vagrantfiles:
+        - test/vagrant_provisions/freebsd_vagrant_provision.rb
+  - name: freebsd-11
+    driver:
+      provision: True
+      vagrantfiles:
+        - test/vagrant_provisions/freebsd_vagrant_provision.rb
+
+provisioner:
+  name: ansible_push
+  ansible_config: test/ansible.cfg
+  chef_bootstrap_url: nil
+
+transport:
+  max_ssh_sessions: 6
+
+suites:
+  - name: suite-tor-default
+    provisioner:
+      playbook: "test/integration/default/default.yml"
+  - name: suite-tor-exit-node
+    provisioner:
+      playbook: "test/integration/default/exit-node.yml"

--- a/README.md
+++ b/README.md
@@ -284,6 +284,18 @@ We do not ultimately trust every tor relay we operate (we try to perform input v
 
 **Be aware that the ansible control machine stores ALL your relay keys (RSA and Ed25519) - apply security measures accordingly.**
 
+Testing
+-----------------------
+
+Install `test-kitchen` and ansible plugin using `gem`:
+
+```bash
+gem install test-kitchen kitchen-ansiblepush kitchen-vagrant
+```
+
+Then you can run tests with `kitchen test`.
+
+Note that to run tests, you also need Vagrant and VirtualBox.
 
 Reporting Security Bugs
 -----------------------

--- a/test/ansible.cfg
+++ b/test/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path=./:../:../../

--- a/test/integration/default/default.yml
+++ b/test/integration/default/default.yml
@@ -1,0 +1,6 @@
+---
+- hosts: all
+  vars_files:
+    - vars/dry-run-vars.yml
+  roles:
+    - ansible-relayor

--- a/test/integration/default/exit-node.yml
+++ b/test/integration/default/exit-node.yml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  vars_files:
+    - vars/dry-run-vars.yml
+  vars:
+    tor_ExitRelay: True
+  roles:
+    - ansible-relayor

--- a/test/integration/default/vars/dry-run-vars.yml
+++ b/test/integration/default/vars/dry-run-vars.yml
@@ -1,0 +1,4 @@
+---
+tor_ContactInfo: "ansible-relayor test-kitchen (you should never see this on a public relay) https://github.com/nusenu/ansible-relayor"
+tor_DisableNetwork: 1
+tor_PublishServerDescriptor: 0

--- a/test/vagrant_provisions/fedora27_vagrant_provision.rb
+++ b/test/vagrant_provisions/fedora27_vagrant_provision.rb
@@ -1,0 +1,5 @@
+Vagrant.configure("2") do |config|
+  config.vm.provision "shell", inline: <<-SHELL
+     sudo dnf install -y python2
+  SHELL
+end

--- a/test/vagrant_provisions/freebsd_vagrant_provision.rb
+++ b/test/vagrant_provisions/freebsd_vagrant_provision.rb
@@ -1,0 +1,6 @@
+Vagrant.configure("2") do |config|
+  config.vm.provision "shell", inline: <<-SHELL
+     sudo pkg install -y python
+     sudo ln -s /usr/local/bin/python /usr/bin/python
+  SHELL
+end


### PR DESCRIPTION
Hello,

I created test-kitchen configuration file for Vagrant driver.

Test Kitchen is used to automatize integration tests of configuration management tools. In this case I set up `.kitchen.yml` fileand there are 2 tests. First one is creation of tor non-exit node and second creation of tor exit node. Configurations of tests are located in `test/integration/default/`.

With Test-Kitchen you can automatically run deployment test of tor relay on almost all systems that you officialy support with exception of OpenBSD which is not supported by kitchen-vagrant driver (Bento repository). Vagrant tests are close to real world use case and they can be done only from your local machine (not using Travis or other CI). Just follow `Testing` part of `README.md` for instruction to use it. 


Notice that during tests I use `tor_DisableNetwork: 1` and `tor_PublishServerDescriptor: 0` to do dry run of tests.

In future we can also test multiple versions of ansible.

This PR was created during my hackaton partly for educational purposes, but I am using your repository and plan to use it more widely during automated deployment of Tor nodes.

Feel free to ask me anything during review.

Kindest Regards
Ondrej