### PR TITLE
Enh/public ip kitchen test

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -40,3 +40,6 @@ suites:
   - name: t-exit
     provisioner:
       playbook: "test/integration/default/exit-node.yml"
+  - name: t-guard-2publicIPs
+    provisioner:
+      playbook: "test/integration/default/guard-node-2-public-ips.yml"

--- a/test/integration/default/guard-node-2-public-ips.yml
+++ b/test/integration/default/guard-node-2-public-ips.yml
@@ -1,0 +1,29 @@
+---
+- hosts: all
+  vars_files:
+    - vars/dry-run-vars.yml
+  vars:
+    - tor_maxPublicIPs: 2
+  roles:
+    - ansible-relayor
+  pre_tasks:
+    - name: Add first RFC 5737 TEST-NET-1 public IP 192.0.2.10/24 (Linux)
+      become: true
+      shell: "ip address add 192.0.2.10/24 dev {{ ansible_default_ipv4['interface'] }}"
+      when: ansible_system == 'Linux'
+    - name: Add first RFC 5737 TEST-NET-1 public IP 192.0.2.10/24 (FreeBSD)
+      become: true
+      shell: "ifconfig {{ ansible_default_ipv4['interface'] }} 192.0.2.10/24 add"
+      when: ansible_system == 'FreeBSD'
+
+    - name: Add second RFC 5737 TEST-NET-2 public IP 198.51.100.10/24 (Linux)
+      become: true
+      shell: "ip address add 198.51.100.10/24 dev {{ ansible_default_ipv4['interface'] }}"
+      when: ansible_system == 'Linux'
+    - name: Add second RFC 5737 TEST-NET-2 public IP 198.51.100.10/24 (FreeBSD)
+      become: true
+      shell: "ifconfig {{ ansible_default_ipv4['interface'] }} 198.51.100.10/24 add"
+      when: ansible_system == 'FreeBSD'
+
+    - name: Re-gather facts
+      setup:


### PR DESCRIPTION
This scenario uses ansible `pre_tasks` to add 2 public IP addresses to default network interface. This approach is better than adding IP addresses to platforms via vagrant ruby provisioner, because we only need to define changes in kitchen scenario (suite).

This scenario uses ansible `pre_tasks` to add 2 public IP addresses to default network
interface.

* First IP address is from RFC 5737 TEST-NET-1 IP range
* Seconds IP address is from RFC 5737 TEST-NET-2 IP range

After ip addresses are set, regather facts must be used to update facts. Scenario overrides default value of 1 `tor_maxPublicIPs` to value 2 in order to use both public addresses.

Please, let me know if we need to update more tor parameters to properly define this scenario and also if using RFC 5737 addresses is not appropriate.

* RFC 5737: https://tools.ietf.org/html/rfc5737

Closes #154.