### PR TITLE
Make the backup option of the template Ansible module configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,11 @@ tor_freebsd_nmbclusters: 30000
 tor_DataDir: /var/lib/tor
 tor_PidDir: /var/run/tor
 
+# Create a backup of the torrc file on the tor server whenever the file is changed.
+# You might want to disable this if you use other means of backups or version
+# control, for example etckeeper.
+tor_backup_torrc: yes
+
 # specify tor's loglevel
 tor_LogLevel: notice
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -205,7 +205,7 @@
     dest: "{{ (ansible_pkg_mgr != 'apt')| ternary(tor_ConfDir ~ '/' ~ item.0.ipv4 ~ '_' ~ item.1.orport ~ '.torrc', tor_ConfDir ~ '/' ~ item.0.ipv4 ~ '_' ~ item.1.orport ~ '/torrc') }}"
     owner: root
     mode: 0644
-    backup: yes
+    backup: "{{ tor_backup_torrc }}"
     validate: "tor --verify-config -f %s"
   with_nested:
    - "{{ tor_ips }}"


### PR DESCRIPTION
I use etckeeper so I have all the versions I ever need and a standard way to get to them.