### PR TITLE
Minor fixes: Add ref to "Automatic Software Updates in the Tor Relay Guide", idempotency issue, typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ no further manual configuration is required.
 
 Keeping the tor package updated (an important task of running a relay) is not in scope of this ansible role.
 We recommend you enable automatic updates to keep your relay well maintained if your OS supports that.
+Refer to [Automatic Software Updates in the Tor Relay Guide](https://trac.torproject.org/projects/tor/wiki/TorRelayGuide#AutomaticSoftwareUpdates).
 
 This ansible role does not aim to support tor bridges.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ tor_ports:
 tor_maxPublicIPs: 1
 
 # We only use a single private IP by default since
-# we can not reliably tell wether we are NATed
+# we can not reliably tell whether we are NATed
 # to more than a single public IP address
 tor_maxPrivateIPs: 1
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -124,7 +124,7 @@
    - "{{ tor_ports }}"
    - [ 'secret_id_key' ]
 
-- name: Fetch RSA key for comparision
+- name: Fetch RSA key for comparison
   become: yes
   fetch:
     src: "{{ tor_DataDir }}/{{ item.0.ipv4 }}_{{ item.1.orport }}/keys/{{ item[2] }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,7 @@
   run_once: true
   become: no
   delegate_to: 127.0.0.1
+  changed_when: False
   tags:
     - always
 


### PR DESCRIPTION
The mentioned "Automatic Software Updates in the Tor Relay Guide" recommendations are automated in DebOps now :), ref: https://github.com/debops/debops/pull/328