### PR TITLE
Fix IPv6 filter workaround

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,21 +75,16 @@ tor_distribution_release: "{{ ansible_lsb.codename }}"
 
 # filter potentially malicious input from relay-provided IPv4/v6 addresses
 # https://docs.ansible.com/ansible/playbooks_filters_ipaddr.html
-tor_available_public_ipv4s: "{{ ansible_all_ipv4_addresses| ipv4('address') | ipv4('public') }}"
+tor_available_public_ipv4s: "{{ ansible_all_ipv4_addresses | ipv4('address') | ipv4('public') }}"
 tor_v4ips: "{{ tor_available_public_ipv4s[0:tor_maxPublicIPs] }}"
-tor_ipv4_count: "{{ tor_v4ips | length|int }}"
+tor_ipv4_count: "{{ tor_v4ips | length }}"
 
 # we can not use more IPv6 IPs than we have IPv4 IPs so we truncate (but fewer is ok)
-tor_available_public_ipv6s: "{{ ansible_all_ipv6_addresses|ipv6('public')|ipv6('address') }}"
-
+tor_available_public_ipv6s: "{{ ansible_all_ipv6_addresses | ipv6('address') | ipv6('public') }}"
+tor_v6ips: "{{ tor_available_public_ipv6s[0:tor_ipv4_count|int] | ipwrap }}"
 
 # This var enables autoconfiguration for OutboundBindAddressExit
 tor_dedicatedExitIP: False
-
-# the following line is commented out and handled in ip-list.yml until
-# https://github.com/ansible/ansible/issues/14829
-# gets fixed
-#tor_v6ips: "{{ tor_v6tmp[0:tor_ipv4_count|int]|ipv6('address') }}"
 
 tor_RunAsDaemon: 1
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,7 +80,7 @@ tor_v4ips: "{{ tor_available_public_ipv4s[0:tor_maxPublicIPs] }}"
 tor_ipv4_count: "{{ tor_v4ips | length }}"
 
 # we can not use more IPv6 IPs than we have IPv4 IPs so we truncate (but fewer is ok)
-tor_available_public_ipv6s: "{{ ansible_all_ipv6_addresses | ipv6('address') | ipv6('public') }}"
+tor_available_public_ipv6s: "{{ ansible_all_ipv6_addresses | ipv6('address') | ipv6('public') | ipwrap }}"
 tor_v6ips: "{{ tor_available_public_ipv6s[0:tor_ipv4_count|int] | ipwrap }}"
 
 # This var enables autoconfiguration for OutboundBindAddressExit

--- a/tasks/ip-list.yml
+++ b/tasks/ip-list.yml
@@ -4,23 +4,6 @@
   include_vars: private_IPv4_only.yml
   when: tor_v4ips == []
 
-# workaround for this ansible IPv6 filter bug
-# https://github.com/ansible/ansible/issues/14829
-# we simply convert False to empty lists
-- name: workaround for ansible bug 14829 (1/3)
-  set_fact:
-    tor_available_public_ipv6s: []
-  when: tor_available_public_ipv6s == False
-
-- name: workaround for ansible bug 14829 (2/3)
-  set_fact:
-    tor_v6ips: "{{ tor_available_public_ipv6s[0:tor_ipv4_count|int]|ipv6('address') }}"
-
-- name: workaround for ansible bug 14829 (3/3)
-  set_fact:
-    tor_v6ips: []
-  when: tor_v6ips == False
-
 - name: setup IP list (1/2)
   set_fact:
     ips:

--- a/templates/torrc
+++ b/templates/torrc
@@ -9,9 +9,9 @@ SocksPort {{ tor_SocksPort }}
 User _tor-{{ item.0.ipv4 }}_{{ item.1.orport }}
 DataDirectory {{ tor_DataDir }}/{{ item.0.ipv4 }}_{{ item.1.orport }}
 ORPort {{ item.0.ipv4 }}:{{ item.1.orport }}
-{% if item.0.ipv6 != "" and item.0.ipv6 != "False" and tor_IPv6 == True %}
-ORPort [{{item.0.ipv6}}]:{{item.1.orport}}
-OutboundBindAddress [{{item.0.ipv6}}]
+{% if item.0.ipv6 != "" and tor_IPv6 == True %}
+ORPort {{ item.0.ipv6 }}:{{ item.1.orport }}
+OutboundBindAddress {{ item.0.ipv6 }}
 {% endif %}
 
 {% if item.1.dirport != 0 %}
@@ -59,10 +59,10 @@ NoExec {{ tor_NoExec }}
 {% if ((tor_ExitRelay == True and tor_ExitRelaySetting_file is not defined) or (tor_ExitRelay == True and tor_ExitRelaySetting_file is defined and (lookup('csvfile', inventory_hostname~'-'~item.0.ipv4~'_'~item.1.orport~' file='~tor_ExitRelaySetting_file~' delimiter=,') == "exit"))) %}
 # we are an exit relay!
 ExitRelay 1
-{% if item.0.ipv6 != "" and item.0.ipv6 != "False" and tor_IPv6 == True and tor_IPv6Exit == True %}
+{% if item.0.ipv6 != "" and tor_IPv6 == True and tor_IPv6Exit == True %}
 IPv6Exit 1
 {% if tor_dedicatedExitIP != True %}
-DirPort [{{ item.0.ipv6 }}]:{{ item.1.dirport }} NoAdvertise
+DirPort {{ item.0.ipv6 }}:{{ item.1.dirport }} NoAdvertise
 {% endif %}
 {% endif %}
 {% if tor_ExitNoticePage == True and tor_DirPortFrontPage is not defined %}
@@ -81,11 +81,11 @@ DirPort {{ tor_available_public_ipv4s[loop_idx + tor_maxPublicIPs]}}:{{ item.1.d
 {% endif %}
 {% if tor_available_public_ipv6s|length >= tor_maxPublicIPs*2 and tor_IPv6 == True and tor_IPv6Exit == True %}
 {% if tor_ports|length == 2 %}
-OutboundBindAddressExit [{{ tor_available_public_ipv6s[(loop_idx/2)|round(0,'floor')|int + tor_maxPublicIPs]}}]
-DirPort [{{ tor_available_public_ipv6s[(loop_idx/2)|round(0,'floor')|int + tor_maxPublicIPs]}}]:{{ item.1.dirport }} NoAdvertise
+OutboundBindAddressExit {{ tor_available_public_ipv6s[(loop_idx/2)|round(0,'floor')|int + tor_maxPublicIPs] }}
+DirPort {{ tor_available_public_ipv6s[(loop_idx/2)|round(0,'floor')|int + tor_maxPublicIPs] }}:{{ item.1.dirport }} NoAdvertise
 {% elif tor_ports|length == 1 %}
-OutboundBindAddressExit [{{ tor_available_public_ipv6s[loop_idx + tor_maxPublicIPs]}}]
-DirPort [{{ tor_available_public_ipv6s[loop_idx + tor_maxPublicIPs]}}]:{{ item.1.dirport }} NoAdvertise
+OutboundBindAddressExit {{ tor_available_public_ipv6s[loop_idx + tor_maxPublicIPs] }}
+DirPort {{ tor_available_public_ipv6s[loop_idx + tor_maxPublicIPs] }}:{{ item.1.dirport }} NoAdvertise
 {% endif %}
 {% endif %}
 {% endif %}
@@ -96,6 +96,7 @@ ExitPolicy {{entry}}
 {% else %}
 ExitRelay 0
 ExitPolicy reject *:*
+ExitPolicy reject6 *:*
 {% endif %}
 
 {% if tor_PublishServerDescriptor is defined %}


### PR DESCRIPTION
Should fix IPv6 filtering(https://github.com/nusenu/ansible-relayor/issues/80), so the workaround shouldn't be needed anymore.

Test playbook used:
```
- hosts: localhost
  gather_facts: yes
  vars:
    tor_maxips: 3
    tor_v4ips: "{{ ansible_all_ipv4_addresses[0:tor_maxips] | ipv4('address') }}"
    ipv4_count: "{{ tor_v4ips | length }}"
    v6tmp: "{{ ansible_all_ipv6_addresses | ipv6('address') | ipv6('public') }}"
    tor_v6ips: "{{ v6tmp[0:ipv4_count|int] | ipwrap }}"
  tasks:
  - debug: var=tor_v4ips
  - debug: var=ipv4_count
  - debug: var=v6tmp
  - debug: var=tor_v6ips
  - name: setup IP list (1/2)
    set_fact:
      ips:
          ipv4: "{{ item.0 }}"
          ipv6: "{{ item.1 }}"
    with_together:
          - "{{ tor_v4ips }}"
          - "{{ tor_v6ips }}"
    register: iptest
  - debug:
      var: iptest
```
Test output with 1 local tor_v4ips and 0 public tor_v6ips:
```
ok: [localhost] => {
    "iptest": {
        "changed": false,
        "msg": "All items completed",
        "results": [
            {
                "_ansible_ignore_errors": null,
                "_ansible_item_label": [
                    "10.0.2.15",
                    null
                ],
                "_ansible_item_result": true,
                "_ansible_no_log": false,
                "ansible_facts": {
                    "ips": {
                        "ipv4": "10.0.2.15",
                        "ipv6": ""
                    }
                },
                "changed": false,
                "failed": false,
                "item": [
                    "10.0.2.15",
                    null
                ]
            }
        ]
    }
}
```
Test output with 3 local tor_v4ips and 2 public tor_v6ips:
```
ok: [localhost] => {
    "iptest": {
        "changed": false,
        "msg": "All items completed",
        "results": [
            {
                "_ansible_ignore_errors": null,
                "_ansible_item_label": [
                    "192.168.0.1",
                    "[IPv6_ADDRESS_1]"
                ],
                "_ansible_item_result": true,
                "_ansible_no_log": false,
                "ansible_facts": {
                    "ips": {
                        "ipv4": "192.168.0.1",
                        "ipv6": "[IPv6_ADDRESS_1]"
                    }
                },
                "changed": false,
                "failed": false,
                "item": [
                    "192.168.0.1",
                    "[IPv6_ADDRESS_1]"
                ]
            },
            {
                "_ansible_ignore_errors": null,
                "_ansible_item_label": [
                    "172.16.0.1",
                    "[IPv6_ADDRESS_2]"
                ],
                "_ansible_item_result": true,
                "_ansible_no_log": false,
                "ansible_facts": {
                    "ips": {
                        "ipv4": "172.16.0.1",
                        "ipv6": "[IPv6_ADDRESS_2]"
                    }
                },
                "changed": false,
                "failed": false,
                "item": [
                    "172.16.0.1",
                    "[IPv6_ADDRESS_2]"
                ]
            },
            {
                "_ansible_ignore_errors": null,
                "_ansible_item_label": [
                    "10.24.50.1",
                    null
                ],
                "_ansible_item_result": true,
                "_ansible_no_log": false,
                "ansible_facts": {
                    "ips": {
                        "ipv4": "10.24.50.1",
                        "ipv6": ""
                    }
                },
                "changed": false,
                "failed": false,
                "item": [
                    "10.24.50.1",
                    null
                ]
            }
        ]
    }
}
```