### PR TITLE
Add Travis CI config with ansible-lint check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+---
+language: python
+python:
+  - '3.6'
+
+install:
+  - pip install ansible-lint
+
+script:
+  - ansible-lint .


### PR DESCRIPTION
This PR adds simple Travis CI with `ansible-lint` command.

In order to make Travis work, you need to integrate Travis with this project, enable CI for this project in Travis and repush commit (or try to force build this PR in Travis) to trigger build.