### PR TITLE
Fix ansible rule 306 and right with it 305.

### DIFF
--- a/tasks/freebsd_prepare.yml
+++ b/tasks/freebsd_prepare.yml
@@ -14,7 +14,7 @@
     sysctl_set: yes
 
 - name: Gather current kern.ipc.somaxconn setting (FreeBSD)
-  shell: "sysctl kern.ipc.somaxconn|cut -d' '  -f2"
+  command: "sysctl -n kern.ipc.somaxconn"
   become: no
   register: tor_currentsomaxconn
   changed_when: False
@@ -30,7 +30,7 @@
 
 - name: Gather current kern.ipc.nmbclusters setting (FreeBSD)
   become: no
-  shell: "sysctl kern.ipc.nmbclusters|cut -d' '  -f2"
+  command: "sysctl -n kern.ipc.nmbclusters"
   register: tor_currentnmbc
   changed_when: False
 

--- a/tasks/openbsd_prepare.yml
+++ b/tasks/openbsd_prepare.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Gather current system-wide file descriptor limits (OpenBSD)
-  shell: "sysctl kern.maxfiles|cut -d= -f2"
+  command: "sysctl -n kern.maxfiles"
   become: no
   register: tor_openbsd_maxfiles
   changed_when: False


### PR DESCRIPTION
Fix using pipe in shell command by using `sysctl -n` to get value of
kernel parameter value without need of pipe.

Right after it use `command` module instead of `shell`, because it is no
longer needed.

Related to https://github.com/nusenu/ansible-relayor/pull/196