### PR TITLE
Fix/ansible lint 503

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -44,3 +44,13 @@
     state: reloaded
   with_items: "{{ tor_instances_tmp.results }}"
   when: item.changed and ansible_system == 'Linux'
+
+- name: Ensure Tor instances are reloaded if its torrc changed (OpenBSD)
+  become: yes
+  service:
+    name: "tor{{ item.item.0.ipv4|replace('.','_') }}_{{ item.item.1.orport }}"
+    state: reloaded
+  with_items: "{{ tor_instances_tmp.results }}"
+  when: item.changed and ansible_system == 'OpenBSD'
+  tags:
+    - reconfigure

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -275,5 +275,6 @@
   notify:
     - Ensure Tor instances are reloaded if its torrc changed (FreeBSD)
     - Ensure Tor instances are reloaded if its torrc changed (Linux)
+    - Ensure Tor instances are reloaded if its torrc changed (OpenBSD)
   tags:
    - reconfigure

--- a/tasks/openbsd_service.yml
+++ b/tasks/openbsd_service.yml
@@ -31,13 +31,3 @@
   with_nested:
    - "{{ tor_ips }}"
    - "{{ tor_ports }}"
-
-- name: Ensure Tor instances are reloaded if its torrc changed (OpenBSD)
-  become: yes
-  service:
-    name: "tor{{ item.item.0.ipv4|replace('.','_') }}_{{ item.item.1.orport }}"
-    state: reloaded
-  with_items: "{{ tor_instances_tmp.results }}"
-  when: item.changed
-  tags:
-   - reconfigure


### PR DESCRIPTION
Fixes ansible-lint issue 503 by moving service restart task into handlers and using notify in tor configuration change.

I was currently not able to do test properly. 

First converge is working fine, torrc configurations are changed and service reloaded.

Issue is, that when after first converge I change `template/torrc` and rerun converge, the torrc files in OpenBSD (`/etc/tor/enabled/10.0.2.15_9000.torrc` and `/etc/tor/enabled/10.0.2.15_9100.torrc`) are not changed and stay the same.

I didn't find anything about caching template files and task definition is looking good.

If somebody has idea, please help. I will try to further investigate.