### PR TITLE
Enh/kitchen dynamic role load

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,7 +26,6 @@ platforms:
 
 provisioner:
   name: ansible_push
-  ansible_config: test/ansible.cfg
   chef_bootstrap_url: nil
   idempotency_test: true
   fail_non_idempotent: true

--- a/test/ansible.cfg
+++ b/test/ansible.cfg
@@ -1,2 +1,0 @@
-[defaults]
-roles_path=./:../:../../

--- a/test/integration/default/2publicIPs-exit-node.yml
+++ b/test/integration/default/2publicIPs-exit-node.yml
@@ -6,4 +6,4 @@
     - tor_maxPublicIPs: 2
     - tor_ExitRelay: True
   roles:
-    - ansible-relayor
+    - "{{ playbook_dir | regex_replace('test/integration/default$') }}"

--- a/test/integration/default/2publicIPs-guard-node.yml
+++ b/test/integration/default/2publicIPs-guard-node.yml
@@ -5,4 +5,4 @@
   vars:
     - tor_maxPublicIPs: 2
   roles:
-    - ansible-relayor
+    - "{{ playbook_dir | regex_replace('test/integration/default$') }}"

--- a/test/integration/default/6publicIPs-dedicatedExitIP-2instPerIP-exit-node.yml
+++ b/test/integration/default/6publicIPs-dedicatedExitIP-2instPerIP-exit-node.yml
@@ -7,4 +7,4 @@
     - tor_dedicatedExitIP: True
     - tor_ExitRelay: True
   roles:
-    - ansible-relayor
+    - "{{ playbook_dir | regex_replace('test/integration/default$') }}"

--- a/test/integration/default/6publicIPs-dedicatedExitIP-singleInstPerIP-exit-node.yml
+++ b/test/integration/default/6publicIPs-dedicatedExitIP-singleInstPerIP-exit-node.yml
@@ -10,4 +10,4 @@
        - orport: 9000
          dirport: 9001
   roles:
-    - ansible-relayor
+    - "{{ playbook_dir | regex_replace('test/integration/default$') }}"

--- a/test/integration/default/exit-node.yml
+++ b/test/integration/default/exit-node.yml
@@ -5,4 +5,4 @@
   vars:
     tor_ExitRelay: True
   roles:
-    - ansible-relayor
+    - "{{ playbook_dir | regex_replace('test/integration/default$') }}"

--- a/test/integration/default/guard-alpha-node.yml
+++ b/test/integration/default/guard-alpha-node.yml
@@ -2,7 +2,7 @@
 - hosts: all
   vars_files:
     - vars/dry-run-vars.yml
-  roles:
-    - ansible-relayor
   vars:
     - tor_alpha: True
+  roles:
+    - "{{ playbook_dir | regex_replace('test/integration/default$') }}"

--- a/test/integration/default/guard-node.yml
+++ b/test/integration/default/guard-node.yml
@@ -3,4 +3,4 @@
   vars_files:
     - vars/dry-run-vars.yml
   roles:
-    - ansible-relayor
+    - "{{ playbook_dir | regex_replace('test/integration/default$') }}"

--- a/test/integration/default/mixed-node.yml
+++ b/test/integration/default/mixed-node.yml
@@ -6,4 +6,4 @@
     tor_ExitRelay: True
     tor_ExitRelaySetting_file: vars/exit-conf
   roles:
-    - ansible-relayor
+    - "{{ playbook_dir | regex_replace('test/integration/default$') }}"


### PR DESCRIPTION
This PR implements dynamic lookup for ansible-relayor role during tests without having to specify user specific path.

It fixes issue with loading different repository role than yours during tests in case you had repository with name `ansible-relayor` cloned in directory below and your repository had different name than `ansible-relayor`.
    
For example I cloned upstream `ansible-relayor` repository and next to it my fork with name `ansible-relayor-fork`.

It is implemented by using special variable `playbook_dir`, which during kitchen testing always points to directory `<MY_REPO_PATH>/test/integration/default/` and then removing string `test/integration/default` if matched in the end of the path.