### PR TITLE
Change handler if torrc is changed on Linux

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -41,7 +41,7 @@
   become: yes
   service:
     name: "tor@{{ item.item.0.ipv4 }}_{{ item.item.1.orport }}.service"
-    state: reloaded
+    state: restarted
   with_items: "{{ tor_instances_tmp.results }}"
   when: item.changed and ansible_system == 'Linux'
 


### PR DESCRIPTION
Reload caused issues when reconfiguring existing relays on Ubuntu 18.04 and Debian 10. Changing the handler to "restarted" solved the issue. Seems to be to overall better choice.