### PR TITLE
Configuration variable for handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,11 @@ All variables mentioned here are optional.
     - if you have relays not managed with this role you must specify the comma separated list of unmanaged relay fingerprints in this variable so they get included in the generated torrc configuration
     - Note: You also need to manually add the list of fingerprints of your relayor managed relays to the unmanaged relay.
     - default: not set
+    
+* `tor_restart_behavior`
+    - Tor instances are reloaded when the tor configuration file is changed (default option).
+    - This can cause errors on the and long runtimes of the playbook on the controll machine because the instance is not reloaded correctly on the server.
+    - Add the variable "tor_restart_behavior: restarted" to the playbook if you are experiencing errors.
 
 This role supports most torrc options documented in the 'SERVER OPTIONS'
 section of tor's manual. Set them via 'tor_OptionName'.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -259,3 +259,7 @@ tor_ExitPolicy:
   - accept *:50002
   - accept *:64738
   - reject *:*
+
+# The default state of handler for reloading the tor instance after making changes to the torrc. 
+# If this causes problems when running a playbook change the variable to "restarted"
+tor_restart_behavior: reloaded

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -34,14 +34,14 @@
   become: yes
   service:
     name: tor
-    state: reloaded
+    state: "{{ tor_restart_behavior }}"
   when: ansible_system == 'FreeBSD'
 
 - name: Ensure Tor instances are reloaded if its torrc changed (Linux)
   become: yes
   service:
     name: "tor@{{ item.item.0.ipv4 }}_{{ item.item.1.orport }}.service"
-    state: reloaded
+    state: "{{ tor_restart_behavior }}"
   with_items: "{{ tor_instances_tmp.results }}"
   when: item.changed and ansible_system == 'Linux'
 
@@ -49,7 +49,7 @@
   become: yes
   service:
     name: "tor{{ item.item.0.ipv4|replace('.','_') }}_{{ item.item.1.orport }}"
-    state: reloaded
+    state: "{{ tor_restart_behavior }}"
   with_items: "{{ tor_instances_tmp.results }}"
   when: item.changed and ansible_system == 'OpenBSD'
   tags:


### PR DESCRIPTION
Previous PR from #205.

Added a default variable for the handler state which reloads tor instance after the torrc configuration file is changed. Now this behavior can be changed from "reloaded" to "restarted" if wanted. 

"Reloaded" caused errors on the controll machine because of the instance could not be reloaded correctly on the target machine (Debian 10 & Ubuntu 18.04). The logs showed that the service failed, but it was started later. This caused long runtimes of the playbook on the ansible machine.