### PR TITLE
Change branch name for Tor nightly builds option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ All variables mentioned here are optional.
 
 * `tor_nightly_builds` boolean
     - Set to True if you want to use Tor nightly builds repo from deb.torproject.org.
-    - nightly builds follow the tor git master branch.
+    - nightly builds follow the tor git main branch.
     - Only supported on Debian and Ubuntu (ignored on other platforms).
     - default: False
 

--- a/tasks/apt_prepare.yml
+++ b/tasks/apt_prepare.yml
@@ -27,7 +27,7 @@
 
 - name: Override tor_alpha_version if nightly builds repo is enabled (APT)
   set_fact:
-    tor_alpha_version: nightly-master
+    tor_alpha_version: nightly-main
     tor_alpha: True
   when: tor_nightly_builds
 


### PR DESCRIPTION
I enabled `tor_nightly_builds` and after running the playbook, I got this error

```
TASK [nusenu.relayor : Ensure torproject.org alpha/nightly repo is present if enabled (APT)] *******
fatal: [raspberrypi-01]: FAILED! => {"changed": false, "msg": "Failed to update apt cache: E:The repository 'https://deb.torproject.org/torproject.org tor-nightly-master-buster Release' does not have a Release file."}
```
Per the distribution index, they are now published as `main`.

https://deb.torproject.org/torproject.org/dists/