### PR TITLE
add tor_instances fact

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -329,10 +329,12 @@
 - name: Set fact tor_instances
   ansible.builtin.set_fact:
     tor_instances: >-
-      {%- set output = [] -%}
-      {%- for ip in tor_ips -%}
+      {%- set output = {} -%}
+      {%- for ips in tor_ips -%}
       {%- for port in tor_ports -%}
-      {%- set _ = output.append(ip.ipv4~'_'~port.orport) -%}
+      {%- set instance_id_unqualified = ips.ipv4~'_'~port.orport -%}
+      {%- set instance_id_qualified = inventory_hostname~'-'~instance_id_unqualified -%}
+      {%- set _ = output.update({instance_id_qualified: { 'ipv4': ips.ipv4, 'ipv6': ips.ipv6, 'port': port, 'instance_id_unqualified': instance_id_unqualified}}) -%}
       {%- endfor -%}
       {%- endfor -%}
       {{ output }}

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -326,6 +326,17 @@
   tags:
     - reconfigure
 
+- name: Set fact tor_instances
+  ansible.builtin.set_fact:
+    tor_instances: >-
+      {%- set output = [] -%}
+      {%- for ip in tor_ips -%}
+      {%- for port in tor_ports -%}
+      {%- set _ = output.append(ip.ipv4~'_'~port.orport) -%}
+      {%- endfor -%}
+      {%- endfor -%}
+      {{ output }}
+
 - name: Ensure prometheus per host scrape configs are in place
   become: true
   ansible.builtin.template:


### PR DESCRIPTION
This set_fact call gives other roles access to the ipv4+orport combination that is used to key various things, such as service instances and the various CSV files used by relayor. That makes it easier for other roles to compose neatly with relayor.